### PR TITLE
chore: use node:alpine base instead of installing node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 # Using alpine image, because it is super slim
-FROM alpine
-
-# Install only bash and nodejs, then remove cached package data
-RUN apk add --update bash && apk add --update nodejs nodejs-npm && rm -rf /var/cache/apk/*
+FROM node:18.13.0-alpine3.16
 
 # Create app directory. This is where source code will be copied to
 RUN mkdir -p /usr/src/app


### PR DESCRIPTION
Uses `node:18.13.0-alpine3.16`, instead of using `alpine` and then installing Node.js using the package manager.

1. Specifying a base image without a version isn't ideal, because eventually this project won't be compatible with the `latest` version. It's better to pin it to a version that's known to work.
2. Same applies to installing dependencies. The apk repos change, and may update, rename, or even remove packages. There is no guarantee this will continue working.

This proposes that the project uses the node:alpine base image, as the runtime environment is already ready. In theory, it should work longer without fuss since the build is **_more_** (but not 100%) reproducible now. (It still fetches npm packages, but that's not something I've set out to solve here as this did not cause any problems for me.)